### PR TITLE
Fix minior spelling mistake in the help

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const build = require('./lib/build')
 program.version(require('./package.json').version)
   .option('-s, --source [path]', 'The path to the plugin directory. If none is given, assumes your current working directory.', absolutePath, process.cwd())
   .option('-o, --output [path]', 'The path to the output directory. If none is given, assumes your current working directory.', absolutePath, process.cwd())
-  .option('-i, --increment [type]', 'Increment the version found `plugin.xml` by release type (major, minor, path) [patch]', /^(major|minor|patch)$/i)
+  .option('-i, --increment [type]', 'Increment the version found `plugin.xml` by release type (major, minor, patch) [patch]', /^(major|minor|patch)$/i)
   .option('-q, --quiet', 'Do not log messages')
   .parse(process.argv)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerschool-plugin-builder",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Creates a zip file from a directory containing needed files for a PowerSchool plugin.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
commit d9e8f70187f26c5c2f9aa95f7ad705b8f113de14
Author: Steven Riehl <sriehl@fastmail.com>
Date:   Thu Oct 18 15:28:30 2018 -0600

    version bump

commit bb3f6111ac7c38c55f45ca553072cc8c2e060304
Author: Steven Riehl <sriehl@fastmail.com>
Date:   Thu Oct 18 15:28:19 2018 -0600

    fix minior spelling mistake